### PR TITLE
Refactor/get expected transaction from history

### DIFF
--- a/src/test/java/uk/gov/companieshouse/pageobjects/companyaddresses/ChangeToRoPage.java
+++ b/src/test/java/uk/gov/companieshouse/pageobjects/companyaddresses/ChangeToRoPage.java
@@ -10,23 +10,10 @@ import uk.gov.companieshouse.pageobjects.AddressPageInterface;
 import uk.gov.companieshouse.pageobjects.ChipsCommonPage;
 import uk.gov.companieshouse.utils.TestContext;
 
-
 public class ChangeToRoPage extends ChipsCommonPage<ChangeToRoPage> implements AddressPageInterface {
 
     public final TestContext testContext;
     public static final Logger log = LoggerFactory.getLogger(ChangeToRoPage.class);
-    @FindBy(how = How.ID, using = "form1:changeOfAddressScreenTabSheet:changeOfAddressScreen"
-            + ":appropriateOfficeAddress:field")
-    private WebElement appropriateOfficeAddressCheckBox;
-
-    /**
-     * Required constructor for class.
-     */
-    public ChangeToRoPage(TestContext testContext) {
-        super(testContext);
-        this.testContext = testContext;
-        PageFactory.initElements(testContext.getWebDriver(),this);
-    }
 
     @FindBy(how = How.ID, using = "form1:changeOfAddressScreenTabSheet:changeOfAddressScreen:registeredOffice:"
             + "address:houseNumber:field")
@@ -40,7 +27,18 @@ public class ChangeToRoPage extends ChipsCommonPage<ChangeToRoPage> implements A
     @FindBy(how = How.ID, using = "form1:changeOfAddressScreenTabSheet:changeOfAddressScreen:registeredOffice:"
             + "address:street:field")
     private WebElement elementRoStreet;
+    @FindBy(how = How.ID, using = "form1:changeOfAddressScreenTabSheet:changeOfAddressScreen"
+            + ":appropriateOfficeAddress:field")
+    private WebElement appropriateOfficeAddressCheckBox;
 
+    /**
+     * Required constructor for class.
+     */
+    public ChangeToRoPage(TestContext testContext) {
+        super(testContext);
+        this.testContext = testContext;
+        PageFactory.initElements(testContext.getWebDriver(), this);
+    }
 
     /**
      * Wait until the address fields are populated after postcode lookup.

--- a/src/test/java/uk/gov/companieshouse/pageobjects/companyaddresses/ChangeToRoPage.java
+++ b/src/test/java/uk/gov/companieshouse/pageobjects/companyaddresses/ChangeToRoPage.java
@@ -15,6 +15,9 @@ public class ChangeToRoPage extends ChipsCommonPage<ChangeToRoPage> implements A
 
     public final TestContext testContext;
     public static final Logger log = LoggerFactory.getLogger(ChangeToRoPage.class);
+    @FindBy(how = How.ID, using = "form1:changeOfAddressScreenTabSheet:changeOfAddressScreen"
+            + ":appropriateOfficeAddress:field")
+    private WebElement appropriateOfficeAddressCheckBox;
 
     /**
      * Required constructor for class.
@@ -63,8 +66,13 @@ public class ChangeToRoPage extends ChipsCommonPage<ChangeToRoPage> implements A
     }
 
     @Override
-    public AddressPageInterface clickLookUp() {
+    public ChangeToRoPage clickLookUp() {
         elementRoLookUp.click();
+        return this;
+    }
+
+    public ChangeToRoPage appropriateOfficeAddressCheckBox() {
+        appropriateOfficeAddressCheckBox.click();
         return this;
     }
 

--- a/src/test/java/uk/gov/companieshouse/stepdefinitions/ChangeOfAddressStepDefs.java
+++ b/src/test/java/uk/gov/companieshouse/stepdefinitions/ChangeOfAddressStepDefs.java
@@ -27,6 +27,7 @@ public class ChangeOfAddressStepDefs {
                 .enterPostCode(address.getPostcode())
                 .clickLookUp()
                 .waitUntilStreetPopulated()
+                .appropriateOfficeAddressCheckBox()
                 .saveForm();
     }
 


### PR DESCRIPTION
I have amended this method based on the time it was taking in a previous test. The test will look through all pages to find the transaction until there are no more pages to find. This is pointless when the transactions are date ordered. So, I am adding a check that if the transaction is not on the first page there is a good chance an error has occurred.

Additionally, this test includes a minor fix to the recent addition of a checkbox for AD01.

Before creating this pull request, I confirm that;

- [ x] I have adhered to the [Pull Request Review Checklist](https://companieshouse.atlassian.net/wiki/spaces/TT/pages/27624876/Pull+Request+Review+Checklist)
- [ x] I have read the [Automation Best Practices](https://companieshouse.atlassian.net/wiki/spaces/TT/pages/215416988/Automation+Best+Practises)
- [x ] Checkstyle passes locally