### PR TITLE
Removed deprecated method

### DIFF
--- a/src/test/java/uk/gov/companieshouse/data/dbutil/DbUtil.java
+++ b/src/test/java/uk/gov/companieshouse/data/dbutil/DbUtil.java
@@ -121,8 +121,7 @@ public class DbUtil {
                 docId = rs.getString("input_document_id");
                 LOG.info("Document ID found: {}.  Continuing with test", docId);
                 break;
-            } catch (SQLException | ClassNotFoundException | InstantiationException
-                     | IllegalAccessException exception) {
+            } catch (SQLException  exception) {
                 if (i == maxTries) {
                     LOG.error("Error attempting to find document ID: {}", exception.getMessage());
                     return null;
@@ -149,7 +148,7 @@ public class DbUtil {
             conn.close();
             LOG.info("Last confirmation statement filed on {}", confirmationStatementDate);
             return confirmationStatementDate;
-        } catch (ClassNotFoundException | SQLException | InstantiationException | IllegalAccessException exception) {
+        } catch (SQLException  exception) {
             throw new RuntimeException("Unable to get confirmation statement date from DB", exception);
         }
 
@@ -175,7 +174,7 @@ public class DbUtil {
             LOG.info("PSC Statement found: {}", pscStatement);
             LOG.info("XML format PSC statement: {}", xmlPscStatement);
             return xmlPscStatement;
-        } catch (ClassNotFoundException | SQLException | InstantiationException | IllegalAccessException exception) {
+        } catch (SQLException exception) {
             throw new RuntimeException("Unable to get PSC statement from DB", exception);
         }
 
@@ -204,7 +203,7 @@ public class DbUtil {
             conn.close();
             LOG.info("PSC found: {} {}", pscForename, pscSurname);
             return pscFullName;
-        } catch (ClassNotFoundException | SQLException | InstantiationException | IllegalAccessException exception) {
+        } catch (SQLException exception) {
             throw new RuntimeException("Unable to get PSC appointment from DB", exception);
         }
 
@@ -225,11 +224,7 @@ public class DbUtil {
     private String dbQueryCriteriaCompanyId(String sql, Object intParameter) throws SQLException {
         String companyNumber = null;
         Connection conn;
-        try {
-            conn = dbGetConnection();
-        } catch (ClassNotFoundException | InstantiationException | IllegalAccessException ex) {
-            throw new RuntimeException(ex);
-        }
+        conn = dbGetConnection();
         do {
             PreparedStatement preparedStatement = createPreparedStatement(conn, sql, intParameter);
             ResultSet resultSet = preparedStatement.executeQuery();
@@ -242,7 +237,7 @@ public class DbUtil {
         return companyNumber;
     }
 
-    private String dbCloneCompany(String companyNumber) throws SQLException, ClassNotFoundException, InstantiationException, IllegalAccessException {
+    private String dbCloneCompany(String companyNumber) throws SQLException {
         final String sql = "{ ? = call tedium_pkg_generic.clonecorporate_body (?) }";
 
         Connection conn = dbGetConnection();
@@ -282,8 +277,7 @@ public class DbUtil {
         }
     }
 
-    private Connection dbGetConnection() throws ClassNotFoundException, SQLException, InstantiationException, IllegalAccessException {
-        Class.forName("oracle.jdbc.driver.OracleDriver").newInstance();
+    private Connection dbGetConnection() throws SQLException {
         String user = testContext.getEnv().config.getString("chips-db-user");
         String pass = testContext.getEnv().config.getString("chips-db-pass");
         String url = testContext.getEnv().config.getString("chips-jdbc");


### PR DESCRIPTION
Class.forName("oracle.jdbc.driver.OracleDriver").newInstance(); is deprecated. In JDBC 4.0 and later, the ServiceLoader mechanism is used to automatically load the JDBC drivers. This means you don't need to explicitly load the JDBC driver using Class.forName(). The JDBC 4.0 drivers include a file named META-INF/services/java.sql.Driver. This file contains the name of the JDBC drivers' implementation classes. When the DriverManager is used to establish a connection, it automatically loads and registers the JDBC drivers.

I've removed the ClassNotFoundException, InstantiationException, and IllegalAccessException from the method signature, as they are no longer needed with this approach.

Before creating this pull request, I confirm that;

- [ x] I have adhered to the [Pull Request Review Checklist](https://companieshouse.atlassian.net/wiki/spaces/TT/pages/27624876/Pull+Request+Review+Checklist)
- [x ] I have read the [Automation Best Practices](https://companieshouse.atlassian.net/wiki/spaces/TT/pages/215416988/Automation+Best+Practises)
- [x ] Checkstyle passes locally